### PR TITLE
Fixed issue with accented character name

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "request-promise": "^4.1.1",
     "rethinkdb": "^2.3.1",
     "socket.io": "1.4.6",
-    "source-map-support": "^0.4.0"
+    "source-map-support": "^0.4.0",
+    "npm install html-entities":"1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "rethinkdb": "^2.3.1",
     "socket.io": "1.4.6",
     "source-map-support": "^0.4.0",
-    "npm install html-entities":"1.2.0"
+    "html-entities":"1.2.0"
   }
 }

--- a/src/controllers/api/character.js
+++ b/src/controllers/api/character.js
@@ -70,7 +70,7 @@ router.get('/:characterName', async (req, res, next) => {
 // WORLD
 
 API.registerCall(
-  '/api/character/world/:worldName/:characterName',
+  '/api/character/:characterName/world/:worldName',
   'Gets the ranking information of a character',
   API.createParameter(':characterName', 'string', 'The name of the player to look up'),
   {
@@ -88,7 +88,7 @@ API.registerCall(
   }
 )
 
-router.get('/world/:worldName/:characterName', async (req, res, next) => {
+router.get('/:characterName/world/:worldName', async (req, res, next) => {
   try{
     const ranking = 'world'
     const attribute = req.params.worldName
@@ -106,7 +106,7 @@ router.get('/world/:worldName/:characterName', async (req, res, next) => {
 // JOB
 
 API.registerCall(
-  '/api/character/job/:jobName/:characterName',
+  '/api/character/:characterName/job/:jobName/',
   'Gets the ranking information of a character',
   API.createParameter(':characterName', 'string', 'The name of the player to look up'),
   {
@@ -124,7 +124,7 @@ API.registerCall(
   }
 )
 
-router.get('/job/:jobName/:characterName', async (req, res, next) => {
+router.get('/:characterName/job/:jobName/', async (req, res, next) => {
   try{
     const ranking = 'job'
     var jobName = req.params.jobName

--- a/src/models/character.js
+++ b/src/models/character.js
@@ -5,6 +5,8 @@ import cacheManager from 'cache-manager'
 import redisStore from 'cache-manager-redis'
 import { ENV, PORT, DATADOG_API_KEY, DATADOG_APP_KEY, REDIS_HOST, REDIS_PORT } from '../environment'
 import FileSystem from 'fs'
+var Entities = require('html-entities').XmlEntities;
+var entities = new Entities()
 
 export default class Character {
   constructor(rethinkData){
@@ -12,7 +14,7 @@ export default class Character {
   }
 
   static async GetCharacter(characterName, ranking, attribute,showRealAvatar) {
-    console.log(characterName)
+    var characterName = encodeURIComponent(characterName)
     if (redisCache) {
       const cachedCharacter = await redisCache.getAsync(getCacheName(ranking, characterName))
       if (cachedCharacter) {
@@ -86,8 +88,7 @@ export default class Character {
         return redisCache.set(getCacheName(ranking, character.name), character)
       }))
     }
-
-    return characters.find((character) => character.name.toLowerCase() == characterName.toLowerCase())
+    return characters.find((character) => encodeURIComponent(entities.decode(character.name)).toLowerCase() == characterName.toLowerCase())
   }
 }
 


### PR DESCRIPTION
When searching with an accented character name, API will return no result. This is because `request-promise` does not accept accented letters in uri. I fixed it by encoding accented components.

Example of the bug:
`GET /api/character/Moká` will return `{"error":"Could not find character"}`